### PR TITLE
Remove maven central repository, use only jcenter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,6 @@
 buildscript {
     repositories {
         jcenter()
-        mavenCentral()
         maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {


### PR DESCRIPTION
jcenter is a super set on top of maven central, so having both of those repositories is redundant, and the preferred one should be jcenter.