### PR TITLE
Adds tutorial screens on first start of the app

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -37,13 +37,17 @@ limitations under the License.
                 android:label="@string/app_name">
         </activity>
         <activity
-                android:name=".ui.FlashScreenActivity"
-                android:label="@string/title_activity_flash_screen">
+                android:name=".ui.FlashScreenActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
 
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
+        </activity>
+        <activity
+                android:name=".ui.tutorial.TutorialActivity"
+                android:theme="@style/Tutorial.Theme.Taverna"
+                android:label="@string/title_activity_flash_screen">
         </activity>
         <activity
                 android:name=".ui.DashboardActivity"

--- a/app/src/main/java/org/apache/taverna/mobile/data/local/PreferencesHelper.java
+++ b/app/src/main/java/org/apache/taverna/mobile/data/local/PreferencesHelper.java
@@ -66,6 +66,8 @@ public class PreferencesHelper {
     private final SharedPreferences sharedPref;
     private Context mContext;
 
+    private static final String IS_FIRST_TIME_LAUNCH = "IsFirstTimeLaunch";
+
     public PreferencesHelper(Context context) {
         sharedPref = PreferenceManager.getDefaultSharedPreferences(context);
         mContext = context;
@@ -155,6 +157,15 @@ public class PreferencesHelper {
 
     private void setUserAvatar(String userAvatar) {
         sharedPref.edit().putString(PREF_KEY_USER_AVATAR, userAvatar).apply();
+    }
+
+    public void setFirstTimeLaunch(boolean isFirstTime) {
+        sharedPref.edit().putBoolean(IS_FIRST_TIME_LAUNCH, isFirstTime);
+        sharedPref.edit().commit();
+    }
+
+    public boolean isFirstTimeLaunch() {
+        return sharedPref.getBoolean(IS_FIRST_TIME_LAUNCH, true);
     }
 
     public Observable<User> saveUserDetail(final User user) {

--- a/app/src/main/java/org/apache/taverna/mobile/data/model/TutorialSliderEnum.java
+++ b/app/src/main/java/org/apache/taverna/mobile/data/model/TutorialSliderEnum.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.taverna.mobile.data.model;
+
+
+import org.apache.taverna.mobile.R;
+
+public enum TutorialSliderEnum {
+
+    SLIDE1(R.layout.tutorial_slide1),
+    SLIDE2(R.layout.tutorial_slide2),
+    SLIDE3(R.layout.tutorial_slide3),
+    SLIDE4(R.layout.tutorial_slide4);
+
+    private int layoutId;
+
+    TutorialSliderEnum(int layout_Id) {
+        layoutId = layout_Id;
+    }
+
+    public int getLayoutId() {
+        return layoutId;
+    }
+
+
+}

--- a/app/src/main/java/org/apache/taverna/mobile/ui/FlashScreenActivity.java
+++ b/app/src/main/java/org/apache/taverna/mobile/ui/FlashScreenActivity.java
@@ -28,6 +28,7 @@ import org.apache.taverna.mobile.R;
 import org.apache.taverna.mobile.data.DataManager;
 import org.apache.taverna.mobile.data.local.PreferencesHelper;
 import org.apache.taverna.mobile.ui.login.LoginActivity;
+import org.apache.taverna.mobile.ui.tutorial.TutorialActivity;
 
 import java.util.concurrent.TimeUnit;
 
@@ -39,13 +40,14 @@ import io.reactivex.schedulers.Schedulers;
 public class FlashScreenActivity extends AppCompatActivity {
 
     private DataManager dataManager;
+    private PreferencesHelper preferencesHelper;
 
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_flash_screen);
-
+        preferencesHelper = new PreferencesHelper(this);
         dataManager = new DataManager(new PreferencesHelper(this));
         Observable.timer(2, TimeUnit.SECONDS)
                 .subscribeOn(Schedulers.io())
@@ -55,9 +57,16 @@ public class FlashScreenActivity extends AppCompatActivity {
                     public void accept(Long aLong) throws Exception {
                         if (!dataManager.getPreferencesHelper().isLoggedInFlag()) {
                             dataManager.getPreferencesHelper().clear();
-                            startActivity(new Intent(FlashScreenActivity.this,
-                                    LoginActivity.class));
-                            (FlashScreenActivity.this).finish();
+                            if (preferencesHelper.isFirstTimeLaunch()) {
+                                startActivity(new Intent(FlashScreenActivity.this,
+                                        TutorialActivity.class));
+                                (FlashScreenActivity.this).finish();
+
+                            } else {
+                                startActivity(new Intent(FlashScreenActivity.this,
+                                        LoginActivity.class));
+                                (FlashScreenActivity.this).finish();
+                            }
                         } else {
                             startActivity(new Intent(FlashScreenActivity.this,
                                     DashboardActivity.class));
@@ -66,10 +75,5 @@ public class FlashScreenActivity extends AppCompatActivity {
                     }
                 });
 
-
-
     }
-
-
-
 }

--- a/app/src/main/java/org/apache/taverna/mobile/ui/adapter/TutorialSliderAdapter.java
+++ b/app/src/main/java/org/apache/taverna/mobile/ui/adapter/TutorialSliderAdapter.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.taverna.mobile.ui.adapter;
+
+import android.content.Context;
+import android.support.v4.view.PagerAdapter;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import org.apache.taverna.mobile.data.model.TutorialSliderEnum;
+
+
+public class TutorialSliderAdapter extends PagerAdapter {
+
+    private Context context;
+    public TutorialSliderAdapter(Context context) {
+        this.context = context;
+    }
+
+    public Object instantiateItem(ViewGroup collection, int position) {
+        TutorialSliderEnum tutorialSliderEnum = TutorialSliderEnum.values()[position];
+        LayoutInflater inflater = LayoutInflater.from(context);
+        ViewGroup layout = (ViewGroup) inflater
+                .inflate(tutorialSliderEnum.getLayoutId(), collection, false);
+        collection.addView(layout);
+        return layout;
+    }
+
+    public void destroyItem(ViewGroup collection, int position, Object view) {
+        collection.removeView((View) view);
+    }
+
+    public int getCount() {
+        return TutorialSliderEnum.values().length;
+    }
+
+    public boolean isViewFromObject(View view, Object object) {
+        return view == object;
+    }
+
+
+}

--- a/app/src/main/java/org/apache/taverna/mobile/ui/tutorial/TutorialActivity.java
+++ b/app/src/main/java/org/apache/taverna/mobile/ui/tutorial/TutorialActivity.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.taverna.mobile.ui.tutorial;
+
+import android.content.Intent;
+import android.os.Build;
+import android.os.Bundle;
+import android.support.v4.view.ViewPager;
+import android.support.v7.app.AppCompatActivity;
+import android.text.Html;
+import android.view.View;
+import android.widget.Button;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+
+import org.apache.taverna.mobile.R;
+import org.apache.taverna.mobile.data.local.PreferencesHelper;
+import org.apache.taverna.mobile.data.model.TutorialSliderEnum;
+import org.apache.taverna.mobile.ui.adapter.TutorialSliderAdapter;
+import org.apache.taverna.mobile.ui.login.LoginActivity;
+
+import butterknife.BindView;
+import butterknife.ButterKnife;
+import butterknife.OnClick;
+
+
+public class TutorialActivity extends AppCompatActivity implements ViewPager.OnPageChangeListener {
+
+    @BindView(R.id.slide_pager)
+    ViewPager slidePager;
+
+    @BindView(R.id.layoutDots)
+    LinearLayout dotsLayout;
+
+    @BindView(R.id.btn_skip)
+    Button bSkip;
+
+    @BindView(R.id.btn_next)
+    Button bNext;
+
+    private PreferencesHelper preferencesHelper;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        preferencesHelper = new PreferencesHelper(this);
+
+        setContentView(R.layout.activity_tutorial);
+
+        ButterKnife.bind(this);
+
+        if (Build.VERSION.SDK_INT >= 21) {
+            getWindow().getDecorView()
+                    .setSystemUiVisibility(View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+                            | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN);
+        }
+
+        addBottomDots(0);
+
+        TutorialSliderAdapter tutorialSliderAdapter = new TutorialSliderAdapter(this);
+        slidePager.setAdapter(tutorialSliderAdapter);
+        slidePager.addOnPageChangeListener(this);
+
+    }
+
+    @OnClick(R.id.btn_skip)
+    public void skipClick(View v) {
+        launchLoginScreen();
+    }
+
+    @OnClick(R.id.btn_next)
+    public void nextClick(View v) {
+        int current = getItem(+1);
+        if (current < TutorialSliderEnum.values().length) {
+            slidePager.setCurrentItem(current);
+        } else {
+            launchLoginScreen();
+        }
+    }
+
+    public void addBottomDots(int currentPage) {
+        TextView[] dots = new TextView[TutorialSliderEnum.values().length];
+
+        int[] colorsActive = getResources().getIntArray(R.array.array_dot_active);
+        int[] colorsInactive = getResources().getIntArray(R.array.array_dot_inactive);
+
+        dotsLayout.removeAllViews();
+        for (int i = 0; i < dots.length; i++) {
+            dots[i] = new TextView(this);
+            dots[i].setText(Html.fromHtml("&#8226;"));
+            dots[i].setTextSize(35);
+            dots[i].setTextColor(colorsInactive[currentPage]);
+            dotsLayout.addView(dots[i]);
+        }
+
+        if (dots.length > 0)
+            dots[currentPage].setTextColor(colorsActive[currentPage]);
+    }
+
+    public int getItem(int i) {
+        return slidePager.getCurrentItem() + i;
+    }
+
+    public void launchLoginScreen() {
+        preferencesHelper.setFirstTimeLaunch(false);
+        startActivity(new Intent(TutorialActivity.this, LoginActivity.class));
+        finish();
+    }
+
+    @Override
+    public void onPageScrolled(int position, float positionOffset, int positionOffsetPixels) {
+
+    }
+
+    @Override
+    public void onPageSelected(int position) {
+        addBottomDots(position);
+
+        if (position == TutorialSliderEnum.values().length - 1) {
+            bNext.setText(getString(R.string.start));
+            bSkip.setVisibility(View.GONE);
+        } else {
+            bNext.setText(getString(R.string.next));
+            bSkip.setVisibility(View.VISIBLE);
+        }
+
+    }
+
+    @Override
+    public void onPageScrollStateChanged(int state) {
+
+    }
+}
+

--- a/app/src/main/res/layout/activity_tutorial.xml
+++ b/app/src/main/res/layout/activity_tutorial.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements. See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:showIn="@layout/activity_tutorial">
+
+
+    <android.support.v4.view.ViewPager
+        android:id="@+id/slide_pager"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+    <LinearLayout
+        android:id="@+id/layoutDots"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/dots_height"
+        android:layout_alignParentBottom="true"
+        android:layout_marginBottom="@dimen/dots_margin_bottom"
+        android:gravity="center"
+        android:orientation="horizontal">
+    </LinearLayout>
+
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/tutorialView_height"
+        android:alpha=".5"
+        android:layout_above="@id/layoutDots"
+        android:background="@android:color/white" />
+
+    <Button
+        android:id="@+id/btn_next"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentBottom="true"
+        android:layout_alignParentRight="true"
+        android:background="@null"
+        android:text="@string/next"
+        android:textColor="@android:color/white" />
+
+    <Button
+        android:id="@+id/btn_skip"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentBottom="true"
+        android:layout_alignParentLeft="true"
+        android:background="@null"
+        android:text="@string/skip"
+        android:textColor="@android:color/white" />
+
+</RelativeLayout>

--- a/app/src/main/res/layout/tutorial_slide1.xml
+++ b/app/src/main/res/layout/tutorial_slide1.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements. See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/bg_screen1">
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_centerInParent="true"
+        android:gravity="center_horizontal"
+        android:orientation="vertical">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/slide_1_title"
+            android:textColor="@android:color/white"
+            android:textSize="@dimen/slide_title"
+            android:textStyle="bold" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/margin_top"
+            android:paddingLeft="@dimen/desc_padding"
+            android:paddingRight="@dimen/desc_padding"
+            android:text="@string/usage_login_accounts"
+            android:textAlignment="center"
+            android:textColor="@android:color/white"
+            android:textSize="@dimen/slide_desc" />
+
+    </LinearLayout>
+</RelativeLayout>

--- a/app/src/main/res/layout/tutorial_slide2.xml
+++ b/app/src/main/res/layout/tutorial_slide2.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements. See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/bg_screen2">
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_centerInParent="true"
+        android:gravity="center_horizontal"
+        android:orientation="vertical">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/slide_2_title"
+            android:textColor="@android:color/white"
+            android:textSize="@dimen/slide_title"
+            android:textStyle="bold" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/margin_top"
+            android:paddingLeft="@dimen/desc_padding"
+            android:paddingRight="@dimen/desc_padding"
+            android:text="@string/usage_dashboard_Text"
+            android:textAlignment="center"
+            android:textColor="@android:color/white"
+            android:textSize="@dimen/slide_desc" />
+
+    </LinearLayout>
+
+
+</RelativeLayout>

--- a/app/src/main/res/layout/tutorial_slide3.xml
+++ b/app/src/main/res/layout/tutorial_slide3.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements. See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/bg_screen3">
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_centerInParent="true"
+        android:gravity="center_horizontal"
+        android:orientation="vertical">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/slide_3_title"
+            android:textColor="@android:color/white"
+            android:textSize="@dimen/slide_title"
+            android:textStyle="bold" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/margin_top"
+            android:paddingLeft="@dimen/desc_padding"
+            android:paddingRight="@dimen/desc_padding"
+            android:text="@string/usage_detail_text"
+            android:textAlignment="center"
+            android:textColor="@android:color/white"
+            android:textSize="@dimen/slide_desc" />
+
+    </LinearLayout>
+
+</RelativeLayout>

--- a/app/src/main/res/layout/tutorial_slide4.xml
+++ b/app/src/main/res/layout/tutorial_slide4.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+       http://www.apache.org/licenses/LICENSE-2.0
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/bg_screen4">
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_centerInParent="true"
+        android:gravity="center_horizontal"
+        android:orientation="vertical">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/slide_4_title"
+            android:textColor="@android:color/white"
+            android:textSize="@dimen/slide_title"
+            android:textStyle="bold" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/margin_top"
+            android:paddingLeft="@dimen/desc_padding"
+            android:paddingRight="@dimen/desc_padding"
+            android:text="@string/usage_menu_Text"
+            android:textAlignment="center"
+            android:textColor="@android:color/white"
+            android:textSize="@dimen/slide_desc" />
+
+    </LinearLayout>
+
+</RelativeLayout>

--- a/app/src/main/res/values-v21/styles.xml
+++ b/app/src/main/res/values-v21/styles.xml
@@ -23,4 +23,8 @@
 
     </style>
 
+    <style name="Tutorial.Theme.Taverna" parent="Base.Theme.Taverna">
+        <item name="android:statusBarColor">@android:color/transparent</item>
+    </style>
+
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -61,4 +61,36 @@
 		<item>@color/orange_light</item>
 	</array>
 
+	<!-- Screens background color-->
+	<color name="bg_screen1">#f64c73</color>
+	<color name="bg_screen2">#20d2bb</color>
+	<color name="bg_screen3">#3395ff</color>
+	<color name="bg_screen4">#3395ff</color>
+
+	<!-- dots inactive colors -->
+	<color name="dot_dark_screen1">#d1395c</color>
+	<color name="dot_dark_screen2">#14a895</color>
+	<color name="dot_dark_screen3">#2278d4</color>
+	<color name="dot_dark_screen4">#2278d4</color>
+
+	<!-- dots active colors -->
+	<color name="dot_light_screen1">#f98da5</color>
+	<color name="dot_light_screen2">#8cf9eb</color>
+	<color name="dot_light_screen3">#93c6fd</color>
+	<color name="dot_light_screen4">#93c6fd</color>
+
+	<array name="array_dot_active">
+		<item>@color/dot_light_screen1</item>
+		<item>@color/dot_light_screen2</item>
+		<item>@color/dot_light_screen3</item>
+		<item>@color/dot_light_screen4</item>
+	</array>
+
+	<array name="array_dot_inactive">
+		<item>@color/dot_dark_screen1</item>
+		<item>@color/dot_dark_screen2</item>
+		<item>@color/dot_dark_screen3</item>
+		<item>@color/dot_dark_screen4</item>
+	</array>
+
 </resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -80,6 +80,7 @@ limitations under the License.
     <dimen name="appName_text_margin">12dp</dimen>
     <dimen name="title_text_size">40sp</dimen>
     <dimen name="logo_margin_top">40dp</dimen>
+
     <dimen name="signup_margin_top">2dp</dimen>
     <dimen name="signup_height">50dp</dimen>
     <dimen name="login_height">50dp</dimen>
@@ -87,5 +88,15 @@ limitations under the License.
     <dimen name="logo_height">70dp</dimen>
     <dimen name="logo_width">70dp</dimen>
     <dimen name="login_button_radius">80dp</dimen>
+
+    <!-- Tutorial Screen -->
+    <dimen name="dots_height">30dp</dimen>
+    <dimen name="dots_margin_bottom">20dp</dimen>
+    <dimen name="img_width_height">120dp</dimen>
+    <dimen name="slide_title">30dp</dimen>
+    <dimen name="slide_desc">16dp</dimen>
+    <dimen name="desc_padding">40dp</dimen>
+    <dimen name="margin_top">20dp</dimen>
+    <dimen name="tutorialView_height">1dp</dimen>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -231,4 +231,17 @@ limitations under the License.
     <string name="pref_key_myexperiment_user">pref_myexperimentuser</string>
     <string name="pref_key_myexperiment_pass">pref_myexperimentpass</string>
     <string name="pref_summary_myexperiment_pass">Myexperiment password</string>
+
+    <string name="next">NEXT</string>
+    <string name="skip">SKIP</string>
+    <string name="start">GOT IT</string>
+
+    <string name="slide_1_title">Login</string>
+
+    <string name="slide_2_title">Dashboard</string>
+
+    <string name="slide_3_title">Workflow</string>
+
+    <string name="slide_4_title">Menus</string>
+
 </resources>


### PR DESCRIPTION
This PR adds tutorial screens on first start of the app.

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the checks with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.

Here is the screenshots of all the slides.
<img width="366" alt="screen shot 2018-03-02 at 6 26 22 am" src="https://user-images.githubusercontent.com/21558765/36878077-5433d300-1de3-11e8-80ae-0ae7e379a483.png">
<img width="370" alt="screen shot 2018-03-02 at 6 26 43 am" src="https://user-images.githubusercontent.com/21558765/36878079-54b405a2-1de3-11e8-9a0f-7501ba45da7f.png">
<img width="367" alt="screen shot 2018-03-02 at 6 27 19 am" src="https://user-images.githubusercontent.com/21558765/36878080-54e790c0-1de3-11e8-926c-9eff65f92432.png">
<img width="370" alt="screen shot 2018-03-02 at 6 27 53 am" src="https://user-images.githubusercontent.com/21558765/36878081-551c676e-1de3-11e8-960a-12beaa19001c.png">
